### PR TITLE
fix for sub result gd 02_parse_translations.t

### DIFF
--- a/t/02_parse_translations.t
+++ b/t/02_parse_translations.t
@@ -242,7 +242,7 @@ sub result_gd {
         'test-word-sense' => {
             'gd' => {
                 'part_of_speech' => 'noun',
-                'language'     => 'Gaelic',
+                'language'     => 'Scottish Gaelic',
                 'translations' => [ 'oraindsear', 'òr-mheas' ]
             }
         }


### PR DESCRIPTION
Language code name corrected for 'gd' is Scottish Gaelic (not 'ga' Gaelic) corrected on failed test.
